### PR TITLE
Airbrakes

### DIFF
--- a/flight_computer.ino
+++ b/flight_computer.ino
@@ -44,7 +44,8 @@ return_code ret_code = REPEAT;
 /*
     Initialization of the data file parameters
  */
-const String fileName = "Datafile.txt";
+const String dataFileName = "DataFile.txt";
+const String airbrakesFileName = "AirbrakesFile.txt";
 unsigned long logEveryKMsec = 10;
 unsigned long prevLogTime; 
 
@@ -89,7 +90,7 @@ void setup()
   }
   else {
     delay(1000);
-    if(init_SD(fileName.c_str())){
+    if(init_SD(DATA_FILE, dataFileName.c_str()) && init_SD(AIRBRAKES_FILE, airbrakesFileName.c_str())){
       Serial.println("Successfully opened file on SD card");
     }
     else{
@@ -103,19 +104,35 @@ void setup()
   pinMode(ARM_BUTTON_PIN, INPUT);
 
   //Delete file?
-  Serial.println("Type 'd'/'k' to delete or keep log file ");
+  Serial.println("Commands: \n 'd': delete data log \n 'ab': delete airbrakes log \n 'both': delete both logs \n 'k': to contineue ");
 
   const unsigned long startedWaiting = millis();
-  const unsigned long waitNMillis = 5000;
+  const unsigned long waitNMillis = 6000;
 
   //Option to remove file using serial for waitNMillis milliseconds
   while(millis() - startedWaiting <= waitNMillis){
     String answer;
     answer = Serial.read(); 
     if (answer == "d"){
-      SD.remove(fileName.c_str());
+      SD.remove(dataFileName.c_str());
       delay(10);
-      init_SD(fileName.c_str());
+      init_SD(DATA_FILE, dataFileName.c_str());
+      break;
+    }
+    else if (answer == "ab") {
+      SD.remove(airbrakesFileName.c_str());
+      delay(10);
+      init_SD(AIRBRAKES_FILE, airbrakesFileName.c_str());
+      break;
+    }
+    else if (answer == "both") {
+      SD.remove(dataFileName.c_str());
+      delay(10);
+      init_SD(DATA_FILE, dataFileName.c_str());
+      delay(10);
+      SD.remove(airbrakesFileName.c_str());
+      delay(10);
+      init_SD(AIRBRAKES_FILE, airbrakesFileName.c_str());
       break;
     }
     else if (answer == "k") {
@@ -152,6 +169,6 @@ void loop()
   //Starting writing to SD card when ARMED 
   if ((current_state >= ARMED) && (millis() - prevLogTime >= logEveryKMsec)) {
       prevLogTime = millis();
-      write_SD(data);
+      write_SD(DATA_FILE, data);
   }
 }

--- a/flight_computer.ino
+++ b/flight_computer.ino
@@ -9,11 +9,11 @@
 */
 
 #include <Wire.h>
-#include "src/sensor_interface/sensor_interface.h"
 #include "src/FSM/states.h"
 #include "src/FSM/transitions.h"
 #include "src/SD_interface/SD_interface.h"
 #include "src/servo_interface/servo_interface.h"
+#include "src/sensor_interface/sensor_interface.h"
  
 /*
     Setup of adresses

--- a/src/FSM/states.cpp
+++ b/src/FSM/states.cpp
@@ -1,2 +1,1 @@
-using namespace std;
 #include "states.h"

--- a/src/FSM/states.h
+++ b/src/FSM/states.h
@@ -1,7 +1,6 @@
 #ifndef STATES_H
 #define STATES_H
 
-//Include states here
 #include "states/idle_state.h"
 #include "states/armed_state.h"
 //#include "liftoff_state.h"
@@ -12,6 +11,7 @@
 #include "states/chute_state.h"
 #include "states/landed_state.h"
 #include "../sensor_interface/sensor_data.h"
+#include <Arduino.h>
 
 //All posible states, NUM_STATES is not a state
 //Liftoff_state not included
@@ -24,11 +24,6 @@ enum state {
 enum return_code { NEXT, REPEAT };
 
 typedef int(*state_func)(double[]);
-//se på denne, funker ikke c, namespace funker ikke i c
-//namespace state {
-//	enum type {
-//		IDLE/* , ARMED, LIFTOFF, BURNOUT,
-//		AIRBRAKES, APOGEE, LANDED*/
-//	};
-//}
+
+
 #endif

--- a/src/FSM/states/airbrakes_state.cpp
+++ b/src/FSM/states/airbrakes_state.cpp
@@ -16,7 +16,7 @@ Parameters parameters = { 1 , 1 , 1 }; //Control parameters (Kp, Ki, Kd)
 unsigned long time_old = 0; // time variable for delta time
 
 float sensor_data[2]={0,0}; //Barometer at index 0 and accelrometer (z-direction)at index 1. Utvides kanskje senere m/pitch
-float estimates[2]; //Estimates from Kalman filter. [height, velocity]
+float estimates[2] = {0,0}; //Estimates from Kalman filter. [height, velocity]
 float reference_v= 200; //reference_velovity
 bool firstIteration = true;
 
@@ -45,8 +45,8 @@ int airbrakes_state(double data[]) {
 	// write values to SD card
 	if ((millis() - lastLog >= logInterval)) {
 		lastLog = millis();
-		double data[3] = {estimates[0], estimates[1], u};
-		write_SD(AIRBRAKES_FILE, data);
+		double values[3] = {(double)estimates[0], (double)estimates[1], (double)u};
+		write_SD(AIRBRAKES_FILE, values);
 	}
 
     // remmember to update this to correct tests

--- a/src/FSM/states/airbrakes_state.cpp
+++ b/src/FSM/states/airbrakes_state.cpp
@@ -1,9 +1,7 @@
-using namespace std;
 #include "../states.h"
 #include "../utilities/airbrakes/controll.h"
 #include "../utilities/airbrakes/interpolation.h"
 #include "../utilities/airbrakes/kalman.h"
-#include "airbrakes_state.h"
 #include "../../servo_interface/servo_interface.h"
 #include "../../SD_interface/SD_interface.h"
 

--- a/src/FSM/states/airbrakes_state.cpp
+++ b/src/FSM/states/airbrakes_state.cpp
@@ -6,7 +6,6 @@ using namespace std;
 #include "airbrakes_state.h"
 #include "../../servo_interface/servo_interface.h"
 #include "../../SD_interface/SD_interface.h"
-#include "Arduino.h"
 
 //initilises variables
 float error = 0; //error used in controller

--- a/src/FSM/states/airbrakes_state.cpp
+++ b/src/FSM/states/airbrakes_state.cpp
@@ -6,6 +6,7 @@ using namespace std;
 #include "airbrakes_state.h"
 #include "../../servo_interface/servo_interface.h"
 #include "../../SD_interface/SD_interface.h"
+#include "Arduino.h"
 
 //initilises variables
 float error = 0; //error used in controller
@@ -41,12 +42,13 @@ int airbrakes_state(double data[]) {
 	if(u >= 0 && u <= 180) {
 		get_servo(AIRBRAKES_SERVO)->write(u); //updates servo position
 	}
-
+	
 	// write values to SD card
 	if ((millis() - lastLog >= logInterval)) {
 		lastLog = millis();
+		// these values may be nan during testing since the lookup table or sensors may be missing
 		double values[3] = {(double)estimates[0], (double)estimates[1], (double)u};
-		write_SD(AIRBRAKES_FILE, values);
+		write_SD(AIRBRAKES_FILE, values, 3);
 	}
 
     // remmember to update this to correct tests

--- a/src/FSM/states/airbrakes_state.h
+++ b/src/FSM/states/airbrakes_state.h
@@ -1,6 +1,5 @@
 #ifndef AIRBRAKES_STATE_H
 #define AIRBRAKES_STATE_H
-#include "Arduino.h"
 
 /*
 	Comment what this function does.

--- a/src/FSM/states/apogee_state.cpp
+++ b/src/FSM/states/apogee_state.cpp
@@ -1,6 +1,4 @@
-using namespace std;
 #include "../states.h"
-#include <Arduino.h>
 
 int apogee_state(double data[]) {
 	return_code ret_code;

--- a/src/FSM/states/armed_state.cpp
+++ b/src/FSM/states/armed_state.cpp
@@ -1,6 +1,4 @@
-using namespace std;
 #include "../states.h"
-#include <Arduino.h>
 
 void runEntry();
 bool entry_ran = false;

--- a/src/FSM/states/burnout_state.cpp
+++ b/src/FSM/states/burnout_state.cpp
@@ -1,4 +1,3 @@
-using namespace std;
 #include "../states.h"
 
 double last_acc_z = 0;

--- a/src/FSM/states/burnout_state.h
+++ b/src/FSM/states/burnout_state.h
@@ -1,6 +1,5 @@
 #ifndef BURNOUT_STATE_H
 #define BURNOUT_STATE_H
-#include <Arduino.h>
 
 /*
 	Comment what this function does.

--- a/src/FSM/states/chute_state.cpp
+++ b/src/FSM/states/chute_state.cpp
@@ -1,6 +1,4 @@
-using namespace std;
 #include "../states.h"
-#include <Arduino.h>
 
 int chute_state(double data[]) {
 	return_code ret_code;

--- a/src/FSM/states/drogue_state.cpp
+++ b/src/FSM/states/drogue_state.cpp
@@ -1,6 +1,4 @@
-using namespace std;
 #include "../states.h"
-#include <Arduino.h>
 
 int drogue_state(double data[]) {
 	return_code ret_code;

--- a/src/FSM/states/idle_state.cpp
+++ b/src/FSM/states/idle_state.cpp
@@ -1,6 +1,4 @@
-using namespace std;
 #include "../states.h"
-#include <Arduino.h>
 
 //Only the arm button should trigger next state
 int idle_state(double data[]) {

--- a/src/FSM/states/landed_state.cpp
+++ b/src/FSM/states/landed_state.cpp
@@ -1,4 +1,3 @@
-using namespace std;
 #include "../states.h"
 
 //Does nothing

--- a/src/FSM/transitions.cpp
+++ b/src/FSM/transitions.cpp
@@ -1,5 +1,4 @@
 #include "transitions.h"
-#include "states.h"
 
 /*
 	First element in array is the source state. The second

--- a/src/SD_interface/SD_interface.cpp
+++ b/src/SD_interface/SD_interface.cpp
@@ -2,20 +2,18 @@
 
 File files[NUM_FILES];
 
-String createDataString(double* data){
+String createDataString(double* data, int len){
   String dataString = "";
-
-  for (int i = 0; i < NUM_TYPES; i++){
+  for (int i = 0; i < len; i++){
     dataString += String(data[i]);
     dataString += ",";
   }
-
   return dataString;
 }
 
-void write_SD(int file, double* data) {
+void write_SD(int file, double* data, int len) {
   if (files[file]) {
-    files[file].println(createDataString(data));
+    files[file].println(createDataString(data, len));
     files[file].flush();
   }
   else {

--- a/src/SD_interface/SD_interface.cpp
+++ b/src/SD_interface/SD_interface.cpp
@@ -19,7 +19,8 @@ void write_SD(int file, double* data) {
     files[file].flush();
   }
   else {
-    Serial.println("Error writing to file");
+    Serial.print("Error writing to file: ");
+    Serial.println(file);
   }
 }
 

--- a/src/SD_interface/SD_interface.cpp
+++ b/src/SD_interface/SD_interface.cpp
@@ -1,8 +1,8 @@
 #include "SD_interface.h"
 
-File dataFile;
+File files[NUM_FILES];
 
-String createDataString(double data[NUM_TYPES]){
+String createDataString(double* data){
   String dataString = "";
 
   for (int i = 0; i < NUM_TYPES; i++){
@@ -13,24 +13,26 @@ String createDataString(double data[NUM_TYPES]){
   return dataString;
 }
 
-void write_SD(double data[NUM_TYPES]) {
-  if (dataFile) {
-    dataFile.println(createDataString(data));
-    dataFile.flush();
+void write_SD(int file, double* data) {
+  if (files[file]) {
+    files[file].println(createDataString(data));
+    files[file].flush();
   }
   else {
-    Serial.println("Error opening file");
+    Serial.println("Error writing to file");
   }
 }
 
-bool init_SD(const char* fileName){
-  dataFile = SD.open(fileName, O_CREAT | O_WRITE);
-  if(dataFile){
+bool init_SD(int file, const char* fileName){
+  files[file] = SD.open(fileName, O_CREAT | O_WRITE);
+  if(files[file]){
     return true;
   }
   return false;
 }
 
 void close_SD() {
-  dataFile.close();
+  for(int i = 0; i < NUM_FILES; i++){
+    files[i].close();
+  }
 }

--- a/src/SD_interface/SD_interface.h
+++ b/src/SD_interface/SD_interface.h
@@ -4,11 +4,15 @@
 #include <SD.h>
 #include "../sensor_interface/sensor_data.h"
 
-String createDataString(double data[NUM_TYPES]);
+enum fileEnum {
+    DATA_FILE, AIRBRAKES_FILE, NUM_FILES
+};
 
-void write_SD(double* data);
+String createDataString(double* data);
 
-bool init_SD(const char* fileName);
+void write_SD(int file, double* data);
+
+bool init_SD(int file, const char* fileName);
 
 void close_SD();
 

--- a/src/SD_interface/SD_interface.h
+++ b/src/SD_interface/SD_interface.h
@@ -8,9 +8,9 @@ enum fileEnum {
     DATA_FILE, AIRBRAKES_FILE, NUM_FILES
 };
 
-String createDataString(double* data);
+String createDataString(double* data, int len);
 
-void write_SD(int file, double* data);
+void write_SD(int file, double* data, int len);
 
 bool init_SD(int file, const char* fileName);
 

--- a/src/SD_interface/SD_interface.h
+++ b/src/SD_interface/SD_interface.h
@@ -2,7 +2,6 @@
 #define SD_INTERFACE_H
 
 #include <SD.h>
-#include "../sensor_interface/sensor_data.h"
 
 enum fileEnum {
     DATA_FILE, AIRBRAKES_FILE, NUM_FILES

--- a/src/sensor_interface/sensor_interface.cpp
+++ b/src/sensor_interface/sensor_interface.cpp
@@ -1,5 +1,4 @@
 #include "sensor_interface.h"
-using namespace std;
 
 /*
     Initialization of the BME and IMU sensor
@@ -38,7 +37,6 @@ void calibrateAGL(){
       pitch = y axis
       yaw   = z axis
 */
-
 void readSensors(double *data){
   //Update BMP280 sensor data
   //Important to read temperature before reading pressure

--- a/src/sensor_interface/sensor_interface.h
+++ b/src/sensor_interface/sensor_interface.h
@@ -1,10 +1,11 @@
 #ifndef SENSOR_INTERFACE_H
 #define SENSOR_INTERFACE_H
 
+#include "sensor_data.h"
 #include "Adafruit_BNO055/Adafruit_BNO055.h"
 #include "BME280/SparkFunBME280.h"
 #include "GPS/gps.h"
-#include "sensor_data.h"
+
 
 const uint8_t IMU_ADDRESS = 0x28;
 


### PR DESCRIPTION
Changes:
1) You can now log to multiple files. A separate file for logging airbrakes data is now implemented.

After debugging this stupid problem for too long I found out that having too long file names made the write process fail without any warning..... use short file names. 

Also the command reader only reads one byte at a time. This means we can only use one letter codes to delete files. We can consider using Serial.readline in the future.

Changes tested with continuous writing for 5 minutes without any errors. 